### PR TITLE
VCR missing eio_main dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -92,6 +92,7 @@
   cmdliner
   logs
   fmt
+  eio_main
   (alcotest :with-test))
  (tags
   (terminal recording playback demo)))

--- a/vcr.opam
+++ b/vcr.opam
@@ -18,6 +18,7 @@ depends: [
   "cmdliner"
   "logs"
   "fmt"
+  "eio_main"
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Was trying to utilize these packages locally and got the following during an `opam install . -y` to my local switch:
```
### output ###
# [...]
# 8 |   eio_main
#       ^^^^^^^^
# Error: Library "eio_main" not found.
# -> required by library "vcr" in _build/default/vcr/lib
# -> required by executable main in vcr/bin/dune:2
# -> required by _build/default/vcr/bin/main.exe
# -> required by _build/install/default/bin/vcr
# -> required by _build/default/vcr.install
# -> required by alias install
```

This PR contributes a fix so that the install works.