### PR TITLE
Add missing components in mosaic.mlx

### DIFF
--- a/mosaic/lib/mlx/mosaic_mlx.ml
+++ b/mosaic/lib/mlx/mosaic_mlx.ml
@@ -44,6 +44,29 @@ let scroll_box ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?sticky_scroll ?sticky_start ?viewport_culling ?autofocus ?on_scroll
     children
 
+(* input doesn't have children but mlx always passes them, so we ignore them *)
+let input ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
+    ?on_paste ?display ?box_sizing ?position ?overflow ?scrollbar_width ?inset
+    ?size ?min_size ?max_size ?aspect_ratio ?margin ?padding ?gap ?align_items
+    ?align_self ?align_content ?justify_items ?justify_self ?justify_content
+    ?flex_direction ?flex_wrap ?flex_grow ?flex_shrink ?flex_basis
+    ?grid_template_rows ?grid_template_columns ?grid_auto_rows
+    ?grid_auto_columns ?grid_auto_flow ?grid_template_areas ?grid_row
+    ?grid_column ?background ?text_color ?focused_background ?focused_text_color
+    ?placeholder ?placeholder_color ?cursor_color ?cursor_style ?cursor_blinking
+    ?max_length ?value ?autofocus ?on_input ?on_change ?on_submit ?children:_ ()
+    =
+  Mosaic.input ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
+    ?on_paste ?display ?box_sizing ?position ?overflow ?scrollbar_width ?inset
+    ?size ?min_size ?max_size ?aspect_ratio ?margin ?padding ?gap ?align_items
+    ?align_self ?align_content ?justify_items ?justify_self ?justify_content
+    ?flex_direction ?flex_wrap ?flex_grow ?flex_shrink ?flex_basis
+    ?grid_template_rows ?grid_template_columns ?grid_auto_rows
+    ?grid_auto_columns ?grid_auto_flow ?grid_template_areas ?grid_row
+    ?grid_column ?background ?text_color ?focused_background ?focused_text_color
+    ?placeholder ?placeholder_color ?cursor_color ?cursor_style ?cursor_blinking
+    ?max_length ?value ?autofocus ?on_input ?on_change ?on_submit ()
+
 let text ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?on_paste ?display ?box_sizing ?position ?overflow ?scrollbar_width ?inset
     ?size ?min_size ?max_size ?aspect_ratio ?margin ?padding ?gap ?align_items
@@ -52,7 +75,7 @@ let text ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?grid_template_rows ?grid_template_columns ?grid_auto_rows
     ?grid_auto_columns ?grid_auto_flow ?grid_template_areas ?grid_row
     ?grid_column ?style ?wrap_mode ?tab_indicator ?tab_indicator_color
-    ?selection_bg ?selection_fg ?selectable ?(children = "") () =
+    ?selection_bg ?selection_fg ?selectable ?(children = []) () =
   Mosaic.text ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?on_paste ?display ?box_sizing ?position ?overflow ?scrollbar_width ?inset
     ?size ?min_size ?max_size ?aspect_ratio ?margin ?padding ?gap ?align_items
@@ -61,7 +84,8 @@ let text ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?grid_template_rows ?grid_template_columns ?grid_auto_rows
     ?grid_auto_columns ?grid_auto_flow ?grid_template_areas ?grid_row
     ?grid_column ?style ?wrap_mode ?tab_indicator ?tab_indicator_color
-    ?selection_bg ?selection_fg ?selectable children
+    ?selection_bg ?selection_fg ?selectable
+    (String.concat "" children)
 
 let code ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?on_paste ?display ?box_sizing ?position ?overflow ?scrollbar_width ?inset
@@ -72,7 +96,7 @@ let code ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?grid_auto_columns ?grid_auto_flow ?grid_template_areas ?grid_row
     ?grid_column ?filetype ?languages ?theme ?conceal ?draw_unstyled_text
     ?wrap_mode ?tab_width ?tab_indicator ?tab_indicator_color ?selection_bg
-    ?selection_fg ?selectable ?(children = "") () =
+    ?selection_fg ?selectable ?(children = []) () =
   Mosaic.code ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?on_paste ?display ?box_sizing ?position ?overflow ?scrollbar_width ?inset
     ?size ?min_size ?max_size ?aspect_ratio ?margin ?padding ?gap ?align_items
@@ -82,7 +106,8 @@ let code ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?grid_auto_columns ?grid_auto_flow ?grid_template_areas ?grid_row
     ?grid_column ?filetype ?languages ?theme ?conceal ?draw_unstyled_text
     ?wrap_mode ?tab_width ?tab_indicator ?tab_indicator_color ?selection_bg
-    ?selection_fg ?selectable children
+    ?selection_fg ?selectable
+    (String.concat "" children)
 
 let markdown ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?on_paste ?display ?box_sizing ?position ?overflow ?scrollbar_width ?inset
@@ -93,7 +118,7 @@ let markdown ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?grid_auto_columns ?grid_auto_flow ?grid_template_areas ?grid_row
     ?grid_column ?style ?wrap_width ?paragraph_wrap ?block_quote_wrap ?headings
     ?code_blocks ?raw_html ?links ?images ?unknown_inline ?unknown_block
-    ?languages ?(children = "") () =
+    ?languages ?(children = []) () =
   Mosaic.markdown ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse
     ?on_key ?on_paste ?display ?box_sizing ?position ?overflow ?scrollbar_width
     ?inset ?size ?min_size ?max_size ?aspect_ratio ?margin ?padding ?gap
@@ -103,4 +128,5 @@ let markdown ?id ?key ?visible ?z_index ?live ?buffer ?ref ?on_mouse ?on_key
     ?grid_auto_columns ?grid_auto_flow ?grid_template_areas ?grid_row
     ?grid_column ?style ?wrap_width ?paragraph_wrap ?block_quote_wrap ?headings
     ?code_blocks ?raw_html ?links ?images ?unknown_inline ?unknown_block
-    ?languages children
+    ?languages
+    (String.concat "" children)

--- a/mosaic/lib/mlx/mosaic_mlx.mli
+++ b/mosaic/lib/mlx/mosaic_mlx.mli
@@ -338,7 +338,7 @@ val text :
   ?selection_bg:Ansi.Color.t ->
   ?selection_fg:Ansi.Color.t ->
   ?selectable:bool ->
-  ?children:string ->
+  ?children:string list ->
   unit ->
   'msg t
 (** [text ?children ()] creates a text element. *)
@@ -998,6 +998,7 @@ val input :
   ?on_input:(string -> 'msg option) ->
   ?on_change:(string -> 'msg option) ->
   ?on_submit:(string -> 'msg option) ->
+  ?children:'msg t list ->
   unit ->
   'msg t
 (** [text_input ()] creates a text input element. *)
@@ -1072,7 +1073,7 @@ val code :
   ?selection_bg:Ansi.Color.t ->
   ?selection_fg:Ansi.Color.t ->
   ?selectable:bool ->
-  ?children:string ->
+  ?children:string list ->
   unit ->
   'msg t
 (** [code ?children ()] creates a syntax-highlighted code element. *)
@@ -1132,7 +1133,7 @@ val markdown :
   ?unknown_inline:Mosaic_markdown.Props.unknown ->
   ?unknown_block:Mosaic_markdown.Props.unknown ->
   ?languages:Mosaic_syntax.Set.t ->
-  ?children:string ->
+  ?children:string list ->
   unit ->
   'msg t
 (** [markdown ?children ()] creates a markdown rendering element. *)


### PR DESCRIPTION
Adding a few touches in mosaic-mlx. Using it here: https://github.com/davesnx/query-json/pull/58/

This PR allows, inputs, code and markdown without children and text with strings as children.

```
<input
  key=(string_of_int model.input_key)
  autofocus=(model.focus = Filter_focus)
  value=model.query
  background=bg_primary
  text_color=text_primary
  focused_background=bg_secondary
  focused_text_color=text_accent
  placeholder="Enter query (e.g., .user.name)"
  on_input=(fun s -> Some (Input_changed s))
  on_submit=(fun _ -> Some Apply_completion)
  size={ width = pct 100; height = px 1 }
/>
```

<text>"Lola"</text>
```
<box flex_direction=Row gap=(gap 2)>
  <fragment>
    <text style=style_muted>"Enter"</text>
    <text style=style_primary>"complete"</text>
    <text style=style_muted>"↑↓"</text>
    <text style=style_primary>"navigate"</text>
    <text style=style_muted>"Ctrl+L"</text>
    <text style=style_primary>"clear"</text>
    <text style=style_muted>"Tab"</text>
    <text style=style_primary>"→ result"</text>
  </fragment>
</box>
```