### PR TITLE
Add atomic primary-screen replay primitives

### DIFF
--- a/matrix/lib/ansi/parser.ml
+++ b/matrix/lib/ansi/parser.ml
@@ -18,6 +18,8 @@ type control =
   | DCH of int
   | ICH of int
   | DECSTBM of int * int
+  | SU of int
+  | SD of int
   | OSC of int * string
   | DCS of string
   | APC of string
@@ -179,6 +181,8 @@ let parse_csi ~params body final : token option =
   | 'P' -> Some (Control (DCH (get 0 1)))
   | '@' -> Some (Control (ICH (get 0 1)))
   | 'r' -> Some (Control (DECSTBM (get 0 1, get 1 0)))
+  | 'S' -> Some (Control (SU (get 0 1)))
+  | 'T' -> Some (Control (SD (get 0 1)))
   | 'm' ->
       let attrs =
         if param_count = 0 then [ `Reset ]

--- a/matrix/lib/ansi/parser.mli
+++ b/matrix/lib/ansi/parser.mli
@@ -31,6 +31,8 @@ type control =
   | ICH of int  (** Insert [n] blank Characters. *)
   | DECSTBM of int * int
       (** Set top and bottom scrolling margins ([CSI top ; bottom r]). *)
+  | SU of int  (** Scroll Up by [n] lines. *)
+  | SD of int  (** Scroll Down by [n] lines. *)
   | OSC of int * string  (** Generic OSC with code and payload. *)
   | DCS of string  (** Device Control String payload. *)
   | APC of string  (** Application Program Command payload. *)

--- a/matrix/lib/matrix.ml
+++ b/matrix/lib/matrix.ml
@@ -342,6 +342,14 @@ let schedule_wakeup t deadline =
 
 let redraw_requested t = t.redraw_requested
 
+let request_immediate_redraw t =
+  if t.closed then ()
+  else if t.control_state <> `Explicit_suspended then (
+    t.redraw_requested <- true;
+    if t.loop_active then t.next_frame_deadline <- Some (t.now ())
+    else t.last_render_time <- Float.neg_infinity;
+    t.wake ())
+
 let refresh_capabilities t =
   let caps = Terminal.capabilities t.terminal in
   let color_depth = if caps.rgb then `Truecolor else `Ansi256 in

--- a/matrix/lib/matrix.ml
+++ b/matrix/lib/matrix.ml
@@ -469,6 +469,8 @@ let apply_primary_op buf = function
       Buffer.add_string buf Ansi.(to_string erase_below_cursor)
   | Primary.Clear_and_home ->
       Buffer.add_string buf Ansi.(to_string clear_and_home)
+  | Primary.Clear_scrollback ->
+      Buffer.add_string buf Ansi.(to_string (erase_display ~mode:`Scrollback))
   | Primary.Scroll_up n -> Buffer.add_string buf Ansi.(to_string (scroll_up ~n))
   | Primary.Set_scroll_region { top; bottom } ->
       Buffer.add_string buf Ansi.(to_string (set_scrolling_region ~top ~bottom))
@@ -504,6 +506,13 @@ let static_write t ~rows text =
   else
     let text = if t.config.raw_mode then normalize_newlines text else text in
     t.primary <- Primary.enqueue_static t.primary { text; rows };
+    request_redraw t
+
+let static_replace t ~rows text =
+  if t.config.mode = `Alt then ()
+  else
+    let text = if t.config.raw_mode then normalize_newlines text else text in
+    t.primary <- Primary.replace_static t.primary { text; rows };
     request_redraw t
 
 (* Immediate action, not part of the frame pipeline — the direct

--- a/matrix/lib/matrix.ml
+++ b/matrix/lib/matrix.ml
@@ -501,18 +501,20 @@ let effective_size t =
   | `Alt -> (t.width, t.height)
   | `Primary -> Primary.effective_size t.primary ~width:t.width
 
-let static_write t ~rows text =
+let static_write ?(preserve_live_region = false) t ~rows text =
   if t.config.mode = `Alt || String.length text = 0 then ()
   else
     let text = if t.config.raw_mode then normalize_newlines text else text in
-    t.primary <- Primary.enqueue_static t.primary { text; rows };
+    t.primary <-
+      Primary.enqueue_static t.primary { text; rows; preserve_live_region };
     request_redraw t
 
-let static_replace t ~rows text =
+let static_replace ?(preserve_live_region = false) t ~rows text =
   if t.config.mode = `Alt then ()
   else
     let text = if t.config.raw_mode then normalize_newlines text else text in
-    t.primary <- Primary.replace_static t.primary { text; rows };
+    t.primary <-
+      Primary.replace_static t.primary { text; rows; preserve_live_region };
     request_redraw t
 
 (* Immediate action, not part of the frame pipeline — the direct

--- a/matrix/lib/matrix.mli
+++ b/matrix/lib/matrix.mli
@@ -318,20 +318,25 @@ val capabilities : app -> Terminal.capabilities
     viewport and leave the live viewport intact. These functions are ignored in
     [`Alt] mode. *)
 
-val static_write : app -> rows:int -> string -> unit
-(** [static_write app ~rows s] queues [s] for insertion before the live
-    viewport, using [rows] as the exact number of terminal rows consumed by [s].
-    The caller is responsible for computing [rows] accurately, for example from
-    {!Grid.active_height} after rendering to a grid.
+val static_write :
+  ?preserve_live_region:bool -> app -> rows:int -> string -> unit
+(** [static_write ?preserve_live_region app ~rows s] queues [s] for insertion
+    before the live viewport, using [rows] as the exact number of terminal rows
+    consumed by [s]. The caller is responsible for computing [rows] accurately,
+    for example from {!Grid.active_height} after rendering to a grid.
 
     In raw mode, lone LF bytes in [s] are normalized to CRLF before queuing so
-    terminal row accounting matches the provided [rows]. *)
+    terminal row accounting matches the provided [rows]. When
+    [preserve_live_region] is [true], the rows scroll directly into terminal
+    history and the live region keeps its current height. *)
 
-val static_replace : app -> rows:int -> string -> unit
-(** [static_replace app ~rows s] queues an atomic replacement of all primary
-    static content. The replacement and the next live frame are emitted in one
-    frame transaction; terminal scrollback is cleared before [s] is written.
-    This function is ignored in [`Alt] mode. *)
+val static_replace :
+  ?preserve_live_region:bool -> app -> rows:int -> string -> unit
+(** [static_replace ?preserve_live_region app ~rows s] queues an atomic
+    replacement of all primary static content. The replacement and the next
+    live frame are emitted in one frame transaction; terminal scrollback is
+    cleared before [s] is written. This function is ignored in [`Alt] mode.
+    [preserve_live_region] has the same meaning as for {!static_write}. *)
 
 val static_clear : app -> unit
 (** [static_clear app] clears the primary screen immediately, discards pending

--- a/matrix/lib/matrix.mli
+++ b/matrix/lib/matrix.mli
@@ -327,6 +327,12 @@ val static_write : app -> rows:int -> string -> unit
     In raw mode, lone LF bytes in [s] are normalized to CRLF before queuing so
     terminal row accounting matches the provided [rows]. *)
 
+val static_replace : app -> rows:int -> string -> unit
+(** [static_replace app ~rows s] queues an atomic replacement of all primary
+    static content. The replacement and the next live frame are emitted in one
+    frame transaction; terminal scrollback is cleared before [s] is written.
+    This function is ignored in [`Alt] mode. *)
+
 val static_clear : app -> unit
 (** [static_clear app] clears the primary screen immediately, discards pending
     static output, and resets the live viewport to the full terminal height. It

--- a/matrix/lib/matrix.mli
+++ b/matrix/lib/matrix.mli
@@ -280,6 +280,11 @@ val redraw_requested : app -> bool
     backend distinguish a frame gated on the render cadence from a loop with no
     pending work. *)
 
+val request_immediate_redraw : app -> unit
+(** [request_immediate_redraw app] requests a one-shot frame without waiting for
+    the configured frame cadence. Subsequent frames continue at the configured
+    cadence. *)
+
 (** {1:queries Terminal queries} *)
 
 val mode : app -> mode
@@ -333,9 +338,9 @@ val static_write :
 val static_replace :
   ?preserve_live_region:bool -> app -> rows:int -> string -> unit
 (** [static_replace ?preserve_live_region app ~rows s] queues an atomic
-    replacement of all primary static content. The replacement and the next
-    live frame are emitted in one frame transaction; terminal scrollback is
-    cleared before [s] is written. This function is ignored in [`Alt] mode.
+    replacement of all primary static content. The replacement and the next live
+    frame are emitted in one frame transaction; terminal scrollback is cleared
+    before [s] is written. This function is ignored in [`Alt] mode.
     [preserve_live_region] has the same meaning as for {!static_write}. *)
 
 val static_clear : app -> unit

--- a/matrix/lib/primary.ml
+++ b/matrix/lib/primary.ml
@@ -18,7 +18,7 @@ type plan = {
 }
 
 type region = { row_offset : int; height : int }
-type static_write = { text : string; rows : int }
+type static_write = { text : string; rows : int; preserve_live_region : bool }
 
 type cursor_anchor = {
   render_offset : int;
@@ -111,17 +111,22 @@ type static_step = {
   next_static_needs_newline : bool;
 }
 
-let static_step t ~offset ~static_needs_newline { text; rows } =
+let static_step t ~offset ~static_needs_newline
+    { text; rows; preserve_live_region } =
   let max_offset = max 0 (t.terminal_height - t.min_live_height) in
   let base = if offset = 0 then 1 else offset in
   let needs_newline = static_needs_newline && not (starts_with_newline text) in
   let payload_rows = rows + if needs_newline then 1 else 0 in
-  let grow_by = min payload_rows (max 0 (max_offset - base)) in
+  let grow_by =
+    if preserve_live_region then 0
+    else min payload_rows (max 0 (max_offset - base))
+  in
   {
     base;
     needs_newline;
     payload_rows;
-    next_offset = (if max_offset = 0 then 0 else base + grow_by);
+    next_offset =
+      (if preserve_live_region || max_offset = 0 then offset else base + grow_by);
     next_static_needs_newline = not (ends_with_newline text);
   }
 
@@ -165,12 +170,12 @@ let reanchor t ~render_offset ~static_needs_newline =
     ~render_offset ~static_needs_newline ~static_queue:t.static_queue
     ~replace_pending:t.replace_pending
 
-let enqueue_static t ({ text; rows } as write) =
+let enqueue_static t ({ text; rows; _ } as write) =
   if rows < 0 then invalid_arg "Primary.enqueue_static: rows must be >= 0";
   if String.length text = 0 then t
   else { t with static_queue = write :: t.static_queue }
 
-let replace_static t ({ text; rows } as write) =
+let replace_static t ({ text; rows; _ } as write) =
   if rows < 0 then invalid_arg "Primary.replace_static: rows must be >= 0";
   let static_queue = if String.length text = 0 then [] else [ write ] in
   { t with static_queue; replace_pending = true }
@@ -232,7 +237,7 @@ let full_height_static_ops step text =
 let flush_full_height_static t queue =
   let ops_rev, static_needs_newline =
     List.fold_left
-      (fun (ops_rev, static_needs_newline) ({ text; rows } as write) ->
+      (fun (ops_rev, static_needs_newline) ({ text; rows; _ } as write) ->
         let step = static_step t ~offset:0 ~static_needs_newline write in
         let step = { step with payload_rows = rows } in
         let ops_rev =
@@ -259,7 +264,11 @@ let flush_static_append t =
   | rev_queue ->
       let queue = List.rev rev_queue in
       let max_offset = max 0 (t.terminal_height - t.min_live_height) in
-      if max_offset = 0 then flush_full_height_static t queue
+      let preserves_live_region =
+        List.for_all (fun write -> write.preserve_live_region) queue
+      in
+      if max_offset = 0 || (t.render_offset = 0 && preserves_live_region) then
+        flush_full_height_static t queue
       else if t.render_offset = max_offset then flush_pinned_static t queue
       else
         let projected_offset, _ = projected_after_static t in

--- a/matrix/lib/primary.ml
+++ b/matrix/lib/primary.ml
@@ -5,6 +5,7 @@ type terminal_op =
   | Erase_line
   | Erase_below
   | Clear_and_home
+  | Clear_scrollback
   | Scroll_up of int
   | Set_scroll_region of { top : int; bottom : int }
   | Reset_scroll_region
@@ -31,6 +32,7 @@ type t = {
   render_offset : int;
   static_needs_newline : bool;
   static_queue : static_write list;
+  replace_pending : bool;
 }
 
 let empty_plan =
@@ -45,7 +47,7 @@ let clamp lo hi v = max lo (min hi v)
 let live_height t = t.terminal_height - t.render_offset
 
 let make ~terminal_height ~min_live_height ~render_offset ~static_needs_newline
-    ~static_queue =
+    ~static_queue ~replace_pending =
   let terminal_height = max 1 terminal_height in
   let min_live_height = min terminal_height (max 1 min_live_height) in
   let render_offset =
@@ -57,12 +59,13 @@ let make ~terminal_height ~min_live_height ~render_offset ~static_needs_newline
     render_offset;
     static_needs_newline;
     static_queue;
+    replace_pending;
   }
 
 let create ~terminal_height ~min_live_height ~render_offset
     ~static_needs_newline =
   make ~terminal_height ~min_live_height ~render_offset ~static_needs_newline
-    ~static_queue:[]
+    ~static_queue:[] ~replace_pending:false
 
 let anchor_of_cursor ~terminal_height ~row ~col =
   let terminal_height = max 1 terminal_height in
@@ -123,16 +126,19 @@ let static_step t ~offset ~static_needs_newline { text; rows } =
   }
 
 let projected_after_static t =
+  let initial =
+    if t.replace_pending then (0, false)
+    else (t.render_offset, t.static_needs_newline)
+  in
   List.fold_left
     (fun (offset, static_needs_newline) write ->
       let step = static_step t ~offset ~static_needs_newline write in
       (step.next_offset, step.next_static_needs_newline))
-    (t.render_offset, t.static_needs_newline)
-    (List.rev t.static_queue)
+    initial (List.rev t.static_queue)
 
 let effective_region t =
-  match t.static_queue with
-  | [] -> live_region t
+  match (t.replace_pending, t.static_queue) with
+  | false, [] -> live_region t
   | _ ->
       let offset, _ = projected_after_static t in
       {
@@ -149,6 +155,7 @@ let resize t ~terminal_height =
     make ~terminal_height ~min_live_height:t.min_live_height
       ~render_offset:t.render_offset
       ~static_needs_newline:t.static_needs_newline ~static_queue:t.static_queue
+      ~replace_pending:t.replace_pending
   in
   let region_changed = live_region next <> live_region t in
   (next, { empty_plan with region_changed; force_full_redraw = region_changed })
@@ -156,13 +163,19 @@ let resize t ~terminal_height =
 let reanchor t ~render_offset ~static_needs_newline =
   make ~terminal_height:t.terminal_height ~min_live_height:t.min_live_height
     ~render_offset ~static_needs_newline ~static_queue:t.static_queue
+    ~replace_pending:t.replace_pending
 
 let enqueue_static t ({ text; rows } as write) =
   if rows < 0 then invalid_arg "Primary.enqueue_static: rows must be >= 0";
   if String.length text = 0 then t
   else { t with static_queue = write :: t.static_queue }
 
-let has_pending_static t = t.static_queue <> []
+let replace_static t ({ text; rows } as write) =
+  if rows < 0 then invalid_arg "Primary.replace_static: rows must be >= 0";
+  let static_queue = if String.length text = 0 then [] else [ write ] in
+  { t with static_queue; replace_pending = true }
+
+let has_pending_static t = t.replace_pending || t.static_queue <> []
 
 let static_ops step text =
   let move = Move_cursor { row = step.base; col = 1 } in
@@ -240,7 +253,7 @@ let flush_full_height_static t queue =
       force_full_redraw = true;
     } )
 
-let flush_static t =
+let flush_static_append t =
   match t.static_queue with
   | [] -> (t, empty_plan)
   | rev_queue ->
@@ -281,10 +294,31 @@ let flush_static t =
         in
         (next, { start_plan with terminal_ops; region_changed })
 
+let flush_static t =
+  if not t.replace_pending then flush_static_append t
+  else
+    let reset =
+      {
+        t with
+        render_offset = 0;
+        static_needs_newline = false;
+        replace_pending = false;
+      }
+    in
+    let next, plan = flush_static_append reset in
+    ( next,
+      {
+        terminal_ops = Clear_and_home :: Clear_scrollback :: plan.terminal_ops;
+        region_changed = live_region next <> live_region t;
+        invalidate_presented = true;
+        force_full_redraw = true;
+      } )
+
 let clear_static t =
   let next =
     make ~terminal_height:t.terminal_height ~min_live_height:t.min_live_height
       ~render_offset:0 ~static_needs_newline:false ~static_queue:[]
+      ~replace_pending:false
   in
   ( next,
     {

--- a/matrix/lib/primary.mli
+++ b/matrix/lib/primary.mli
@@ -52,11 +52,12 @@ type region = { row_offset : int; height : int }
 
     [row_offset] is zero-based. [height] is the number of live viewport rows. *)
 
-type static_write = { text : string; rows : int }
+type static_write = { text : string; rows : int; preserve_live_region : bool }
 (** A pending static write.
 
     [rows] is the exact number of terminal rows consumed by [text]. The caller
-    is responsible for computing it. *)
+    is responsible for computing it. When [preserve_live_region] is [true], the
+    write scrolls directly into history without shrinking the live region. *)
 
 type cursor_anchor = {
   render_offset : int;

--- a/matrix/lib/primary.mli
+++ b/matrix/lib/primary.mli
@@ -29,6 +29,7 @@ type terminal_op =
   | Erase_line  (** Erase the current terminal row. *)
   | Erase_below  (** Erase from cursor to the end of the screen. *)
   | Clear_and_home  (** Clear the screen and move the cursor home. *)
+  | Clear_scrollback  (** Clear the terminal's native scrollback. *)
   | Scroll_up of int  (** Scroll the current terminal viewport up by rows. *)
   | Set_scroll_region of { top : int; bottom : int }
       (** Set DECSTBM to one-based inclusive rows. *)
@@ -134,6 +135,11 @@ val reanchor : t -> render_offset:int -> static_needs_newline:bool -> t
 val enqueue_static : t -> static_write -> t
 (** [enqueue_static t write] queues [write] for the next static flush. Empty
     text is ignored. Raises [Invalid_argument] if [write.rows < 0]. *)
+
+val replace_static : t -> static_write -> t
+(** [replace_static t write] queues an atomic replacement of all static
+    primary-screen content for the next flush. The replacement may be empty.
+    Raises [Invalid_argument] if [write.rows < 0]. *)
 
 val has_pending_static : t -> bool
 (** [has_pending_static t] is [true] iff [t] has queued static writes. *)

--- a/matrix/lib/vte/vte.ml
+++ b/matrix/lib/vte/vte.ml
@@ -849,6 +849,8 @@ let handle_control t ctrl =
         t.scroll_region.top <- top - 1;
         t.scroll_region.bottom <- bottom - 1;
         set_cursor_pos t ~row:0 ~col:0)
+  | Ansi.Parser.SU n -> scroll_up t n
+  | Ansi.Parser.SD n -> scroll_down t n
   | Ansi.Parser.OSC (0, title) | Ansi.Parser.OSC (2, title) -> t.title <- title
   | Ansi.Parser.OSC _ -> () (* Ignore other OSC *)
   | Ansi.Parser.DCS _ | Ansi.Parser.APC _ | Ansi.Parser.PM _ | Ansi.Parser.SOS _

--- a/matrix/lib/vte/vte.ml
+++ b/matrix/lib/vte/vte.ml
@@ -450,6 +450,13 @@ let push_to_scrollback t row =
       sb.head <- (sb.head + 1) mod sb.capacity;
       if sb.count < sb.capacity then sb.count <- sb.count + 1
 
+let clear_scrollback t =
+  match t.scrollback with
+  | None -> ()
+  | Some sb ->
+      sb.head <- 0;
+      sb.count <- 0
+
 let scroll_up t n =
   if n <= 0 then ()
   else
@@ -742,10 +749,11 @@ let handle_control t ctrl =
           erase_region t ~x:0 ~y:t.cursor.row ~width:(t.cursor.col + 1)
             ~height:1;
           mark_rows_dirty t 0 t.cursor.row
-      | 2 | 3 ->
+      | 2 ->
           (* Clear entire screen *)
           erase_region t ~x:0 ~y:0 ~width:t.cols ~height:t.rows;
           mark_rows_dirty t 0 (t.rows - 1)
+      | 3 -> clear_scrollback t
       | _ -> ())
   | Ansi.Parser.EL n ->
       (match n with
@@ -932,11 +940,7 @@ let reset t =
   t.title <- "";
 
   (* Clear scrollback *)
-  (match t.scrollback with
-  | Some sb ->
-      sb.head <- 0;
-      sb.count <- 0
-  | None -> ());
+  clear_scrollback t;
 
   t.scroll_region.top <- 0;
   t.scroll_region.bottom <- t.rows - 1;

--- a/matrix/test/test_ansi.ml
+++ b/matrix/test/test_ansi.ml
@@ -679,7 +679,9 @@ let roundtrip_screen_sequences () =
   test_screen "erase line 0" (erase_line ~mode:`Right) (Parser.EL 0);
   test_screen "erase line 2" (erase_line ~mode:`All) (Parser.EL 2);
   test_screen "insert lines" (insert_lines ~n:5) (Parser.IL 5);
-  test_screen "delete lines" (delete_lines ~n:3) (Parser.DL 3)
+  test_screen "delete lines" (delete_lines ~n:3) (Parser.DL 3);
+  test_screen "scroll up" (scroll_up ~n:4) (Parser.SU 4);
+  test_screen "scroll down" (scroll_down ~n:2) (Parser.SD 2)
 
 let roundtrip_sgr_sequences () =
   (* Test that SGR sequences round-trip through parser *)

--- a/matrix/test/test_runtime.ml
+++ b/matrix/test/test_runtime.ml
@@ -1146,6 +1146,30 @@ let test_static_clear_resets_primary_layout () =
   is_false ~msg:"static clear discards pending static output"
     (contains_substring "pending" output)
 
+let test_static_replace_replays_inside_next_frame () =
+  let app, state =
+    make_app ~mode:`Primary ~terminal_tty:true ~render_offset:10
+      ~target_fps:None ~input_timeout:(Some 0.) ()
+  in
+  set_sync_capable app;
+  Matrix.submit app;
+  Buffer.clear state.output;
+  Buffer.clear state.terminal_output;
+  Matrix.static_replace app ~rows:2 "replacement-a\nreplacement-b\n";
+  equal ~msg:"static replacement is deferred until the next frame" string ""
+    (Buffer.contents state.terminal_output);
+  Matrix.prepare app;
+  Matrix.Grid.draw_text (Matrix.grid app) ~x:0 ~y:0 ~text:"live-after";
+  Matrix.submit app;
+  let output = output state in
+  is_true ~msg:"replacement clears terminal scrollback"
+    (contains_substring "\027[3J" output);
+  is_true ~msg:"replacement content precedes the live repaint"
+    (is_before ~first:"replacement-b" ~second:"live-after" output);
+  is_true ~msg:"replacement and live repaint share synchronized output"
+    (is_before ~first:"\027[?2026h" ~second:"replacement-a" output
+    && is_before ~first:"live-after" ~second:"\027[?2026l" output)
+
 let test_primary_full_redraw_does_not_erase_past_terminal_bottom () =
   let app, state =
     make_app ~mode:`Primary ~render_offset:10 ~target_fps:None
@@ -1343,6 +1367,8 @@ let () =
             test_prepare_uses_pending_static_effective_region;
           test "static_clear resets primary layout"
             test_static_clear_resets_primary_layout;
+          test "static_replace replays inside next frame"
+            test_static_replace_replays_inside_next_frame;
           test "primary full redraw does not erase past terminal bottom"
             test_primary_full_redraw_does_not_erase_past_terminal_bottom;
           test "primary full redraw erases stale rows below content"

--- a/matrix/test/test_runtime.ml
+++ b/matrix/test/test_runtime.ml
@@ -1091,6 +1091,25 @@ let test_primary_column_one_anchor_preserves_current_row () =
   is_true ~msg:"column-one anchor preserves the shell-owned row"
     (contains_substring "\r\nHEADER" output)
 
+let test_preserved_static_write_keeps_live_region () =
+  let app, state =
+    make_app ~mode:`Primary ~min_tui_height:1 ~target_fps:None
+      ~input_timeout:(Some 0.) ()
+  in
+  let before = Matrix.size app in
+  Matrix.submit app;
+  Buffer.clear state.output;
+  Matrix.static_write ~preserve_live_region:true app ~rows:2
+    "PRESERVED00\nPRESERVED01\n";
+  equal ~msg:"pending preserved write keeps effective live size" (pair int int)
+    before (Matrix.effective_size app);
+  Matrix.submit app;
+  let output = output state in
+  is_true ~msg:"preserved rows scroll directly into terminal history"
+    (contains_substring "\027[2S" output);
+  equal ~msg:"preserved write keeps live region" (pair int int) before
+    (Matrix.size app)
+
 let test_full_height_consecutive_static_writes_scroll_once_per_row () =
   let app, state =
     make_app ~mode:`Primary ~min_tui_height:24 ~target_fps:None
@@ -1408,6 +1427,8 @@ let () =
             test_primary_required_rows_apply_before_static_flush;
           test "full-height static write scrolls into scrollback"
             test_full_height_static_write_scrolls_into_scrollback;
+          test "preserved static write keeps live region"
+            test_preserved_static_write_keeps_live_region;
           test "full-height consecutive static writes scroll once per row"
             test_full_height_consecutive_static_writes_scroll_once_per_row;
           test "static_write is ignored in alt mode"

--- a/matrix/test/test_runtime.ml
+++ b/matrix/test/test_runtime.ml
@@ -249,6 +249,33 @@ let test_request_redraw_while_paused () =
       | _ -> Matrix.stop app);
   equal ~msg:"redraw triggers one-shot frame while paused" int 2 !frames
 
+let test_immediate_redraw_bypasses_live_cadence_once () =
+  let app, state =
+    make_app ~target_fps:(Some 1.) ~input_timeout:None ~sleep_until_timeout:true
+      ~emit_event_each_read:(Some Matrix.Input.Focus) ~stop_after_reads:5000 ()
+  in
+  let frames = ref 0 in
+  let request_at = ref None in
+  let second_frame_at = ref 0. in
+  Matrix.run app
+    ~on_input:(fun app _event ->
+      match !request_at with
+      | None ->
+          request_at := Some state.now_s;
+          Matrix.request_immediate_redraw app
+      | Some _ -> ())
+    ~on_render:(fun app ->
+      incr frames;
+      if !frames = 2 then (
+        second_frame_at := state.now_s;
+        Matrix.stop app));
+  equal ~msg:"one immediate follow-up frame" int 2 !frames;
+  match !request_at with
+  | Some requested ->
+      is_true ~msg:"follow-up bypasses one-second cadence"
+        (!second_frame_at -. requested < 0.1)
+  | None -> fail "missing redraw request"
+
 let test_idle_does_not_force_live_loop () =
   let app, _state =
     make_app ~target_fps:None ~input_timeout:(Some 0.) ~stop_after_reads:1 ()
@@ -1102,7 +1129,8 @@ let test_preserved_static_write_keeps_live_region () =
   Matrix.static_write ~preserve_live_region:true app ~rows:2
     "PRESERVED00\nPRESERVED01\n";
   equal ~msg:"pending preserved write keeps effective live size" (pair int int)
-    before (Matrix.effective_size app);
+    before
+    (Matrix.effective_size app);
   Matrix.submit app;
   let output = output state in
   is_true ~msg:"preserved rows scroll directly into terminal history"
@@ -1316,6 +1344,8 @@ let () =
       group "Control"
         [
           test "request_redraw while paused" test_request_redraw_while_paused;
+          test "immediate redraw bypasses live cadence once"
+            test_immediate_redraw_bypasses_live_cadence_once;
           test "idle does not force live loop"
             test_idle_does_not_force_live_loop;
         ];

--- a/matrix/test/test_vte.ml
+++ b/matrix/test/test_vte.ml
@@ -365,6 +365,16 @@ let scrollback_accumulates () =
   let lines = Vte.scrollback_lines vte in
   equal ~msg:"scrollback list length" int 2 (List.length lines)
 
+let erase_scrollback_sequence () =
+  let vte = Vte.create ~scrollback:100 ~rows:3 ~cols:10 () in
+  Vte.feed_string vte "L1\nL2\nL3\nL4\nL5";
+  is_true ~msg:"fixture has scrollback" (Vte.scrollback_size vte > 0);
+  let visible = get_line (Vte.grid vte) 0 in
+  Vte.feed_string vte "\x1b[3J";
+  equal ~msg:"ED 3 clears native scrollback" int 0 (Vte.scrollback_size vte);
+  equal ~msg:"ED 3 preserves the visible screen" string visible
+    (get_line (Vte.grid vte) 0)
+
 let scrollback_ring_buffer () =
   let vte = Vte.create ~scrollback:2 ~rows:2 ~cols:5 () in
   Vte.feed_string vte "L1\nL2\nL3\nL4\nL5";
@@ -612,6 +622,7 @@ let tests =
     test "reverse index moves cursor up" reverse_index_moves_cursor_up;
     test "reverse index scrolls region down" reverse_index_scrolls_region_down;
     test "scrollback accumulates" scrollback_accumulates;
+    test "erase scrollback sequence" erase_scrollback_sequence;
     test "scrollback ring buffer" scrollback_ring_buffer;
     test "scrollback disabled" scrollback_disabled;
     test "auto wrap mode" auto_wrap_mode;

--- a/matrix/test/test_vte.ml
+++ b/matrix/test/test_vte.ml
@@ -321,6 +321,17 @@ let scroll_down_basic () =
   equal ~msg:"top cleared" string "" (get_line (Vte.grid vte) 0);
   equal ~msg:"line moved down" string "L1" (get_line (Vte.grid vte) 1)
 
+let csi_scroll_sequences () =
+  let vte = Vte.create ~scrollback:100 ~rows:5 ~cols:20 () in
+  Vte.feed_string vte "L1\nL2\nL3\nL4\nL5";
+  Vte.feed_string vte "\x1b[2S";
+  equal ~msg:"CSI S moves rows up" string "L3" (get_line (Vte.grid vte) 0);
+  equal ~msg:"CSI S records native scrollback" int 2 (Vte.scrollback_size vte);
+  Vte.feed_string vte "\x1b[1T";
+  equal ~msg:"CSI T inserts a blank top row" string ""
+    (get_line (Vte.grid vte) 0);
+  equal ~msg:"CSI T moves content down" string "L3" (get_line (Vte.grid vte) 1)
+
 let scroll_on_bottom_line () =
   let vte = Vte.create ~rows:3 ~cols:10 () in
   Vte.feed_string vte "L1\nL2\nL3\nL4";
@@ -596,6 +607,7 @@ let tests =
     test "cursor save/restore" cursor_save_restore;
     test "scroll up basic" scroll_up_basic;
     test "scroll down basic" scroll_down_basic;
+    test "CSI scroll sequences" csi_scroll_sequences;
     test "scroll on bottom line" scroll_on_bottom_line;
     test "reverse index moves cursor up" reverse_index_moves_cursor_up;
     test "reverse index scrolls region down" reverse_index_scrolls_region_down;


### PR DESCRIPTION
## Summary

- add atomic primary-screen static replacement with scrollback clearing
- allow static writes to preserve the full live region while rows enter native scrollback
- emulate SU/SD and ED 3 in the VTE used by runtime tests
- add a one-shot immediate redraw request that bypasses one frame deadline without changing the configured cadence

These are generic Matrix primitives; retained transcript policy remains application-owned.

## Verification

- `opam exec --switch=5.4.1 -- dune runtest matrix/test`
- 41 existing/new runtime tests at the static-replacement commit, now 43 with immediate redraw
- 64 VTE tests, including SU/SD and ED 3 coverage
